### PR TITLE
Fixes issue #16 by resetting count_output at the beginning of a new m…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1571,7 +1571,7 @@ impl<R: Read> Decompressor<R> {
 				},
 				State::HeaderMetaBlockBegin => {
 					self.meta_block.header = MetaBlockHeader::new();
-
+					self.meta_block.count_output = 0;
 					self.state = match self.parse_is_last() {
 						Ok(state) => state,
 						Err(e) => return Err(e),


### PR DESCRIPTION
This fixes the issue I had with a number of PDFs I was compressing with -q 2
I will run more extensive tests later