### PR TITLE
Fixed compiler warnings.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,31 @@
 extern crate brotli;
 
-use std::io;
-use std::io::{Read, Write};
+use std::io::Read;
 use brotli::Decompressor;
 use std::fs;
 use std::path::Path;
 
-fn visit_dirs(dir: &Path) -> io::Result<()> {
-	if try!(fs::metadata(dir)).is_dir() {
-		for entry in try!(fs::read_dir(dir)) {
-			let entry = try!(entry);
-			if try!(fs::metadata(entry.path())).is_dir() {
-				;
-			} else {
-				if entry.file_name().to_str().unwrap().starts_with("id") {
-					println!("{:?}:", &entry.path());
-					let mut input = Vec::new();
-					let res = Decompressor::new(std::fs::File::open(&entry.path()).unwrap()).read_to_end(&mut input);
-
-					println!("output length = {:?}", input.len());
-					println!("res = {:?}\n===========\n", res);
-				}
-
-			}
-		}
-	}
-	Ok(())
-}
+// fn visit_dirs(dir: &Path) -> io::Result<()> {
+// 	if try!(fs::metadata(dir)).is_dir() {
+// 		for entry in try!(fs::read_dir(dir)) {
+// 			let entry = try!(entry);
+// 			if try!(fs::metadata(entry.path())).is_dir() {
+// 				;
+// 			} else {
+// 				if entry.file_name().to_str().unwrap().starts_with("id") {
+// 					println!("{:?}:", &entry.path());
+// 					let mut input = Vec::new();
+// 					let res = Decompressor::new(std::fs::File::open(&entry.path()).unwrap()).read_to_end(&mut input);
+//
+// 					println!("output length = {:?}", input.len());
+// 					println!("res = {:?}\n===========\n", res);
+// 				}
+//
+// 			}
+// 		}
+// 	}
+// 	Ok(())
+// }
 
 
 

--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -83,7 +83,7 @@ fn should_retrieve_last_item() {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-enum RingBufferError {
+pub enum RingBufferError {
 	ParameterExceededSize,
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -319,7 +319,7 @@ fn should_decompress_quickfox_repeated() {
 	let mut expected = &mut String::new();
 	let _ = std::fs::File::open("data/quickfox_repeated").unwrap().read_to_string(&mut expected);
 
-	assert_eq!(expected, decompressed);
+	assert!(expected == decompressed);
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn should_decompress_asyoulik_txt() {
 	let mut expected = &mut Vec::new();
 	let _ = std::fs::File::open("data/asyoulik.txt").unwrap().read_to_end(&mut expected);
 
-	assert_eq!(expected, decompressed);
+	assert!(expected == decompressed);
 }
 
 #[test]
@@ -355,7 +355,7 @@ fn should_decompress_alice29_txt() {
 	let mut expected = &mut Vec::new();
 	let _ = std::fs::File::open("data/alice29.txt").unwrap().read_to_end(&mut expected);
 
-	assert_eq!(expected, decompressed);
+	assert!(expected == decompressed);
 }
 
 #[test]
@@ -373,7 +373,7 @@ fn should_decompress_metablock_reset() {
 	let mut expected = &mut Vec::new();
 	let _ = std::fs::File::open("data/metablock_reset").unwrap().read_to_end(&mut expected);
 
-	assert_eq!(expected, decompressed);
+	assert!(expected == decompressed);
 }
 
 #[test]


### PR DESCRIPTION
This squelches the handful of compiler warnings which were being generated.

It also swaps some `assert_eq!` instances for `assert!`s, since these can result in very lengthy console messages of essentially binary data.